### PR TITLE
Fix publish date reset when editing post

### DIFF
--- a/src/Form/Blog/PostType.php
+++ b/src/Form/Blog/PostType.php
@@ -51,7 +51,7 @@ class PostType extends AbstractType
             ])
             ->add('publishedAt', DateType::class, [
                 'widget' => 'single_text',
-                'format' => 'yyyy-mm-dd',
+                'format' => 'yyyy-MM-dd',
                 'required' => false,
                 'attr' => ['class' => 'datepicker'],
                 'label' => 'Date de publication',


### PR DESCRIPTION
Lower case m is for minutes where as upper case M is for month

See here for more information: http://userguide.icu-project.org/formatparse/datetime#TOC-Date-Time-Format-Syntax

Fixes #33 