### PR TITLE
Manage admin users

### DIFF
--- a/config/services.yaml
+++ b/config/services.yaml
@@ -4,6 +4,7 @@
 # Put parameters here that don't need to change on each machine where the app is deployed
 # https://symfony.com/doc/current/best_practices/configuration.html#application-related-configuration
 parameters:
+    users_pictures_directory: '%kernel.project_dir%/public/uploads/users'
     partners_logo_directory: '%kernel.project_dir%/public/uploads/partners'
     members_pictures_directory: '%kernel.project_dir%/public/uploads/members'
     posts_pictures_directory: '%kernel.project_dir%/public/uploads/posts'

--- a/src/Controller/Admin/AdminController.php
+++ b/src/Controller/Admin/AdminController.php
@@ -3,8 +3,13 @@
 namespace App\Controller\Admin;
 
 use App\Entity\User\User;
+use App\Form\Admin\UserType;
+use App\Service\FileUploader;
+use Doctrine\Common\Persistence\ObjectManager;
 use Sensio\Bundle\FrameworkExtraBundle\Configuration\IsGranted;
 use Symfony\Bundle\FrameworkBundle\Controller\AbstractController;
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpFoundation\Response;
 use Symfony\Component\Routing\Annotation\Route;
 
 /**
@@ -23,11 +28,48 @@ class AdminController extends AbstractController
 
     /**
      * @Route("/users", name="admin_users")
+	 * @IsGranted("ROLE_ADMIN")
      */
     public function users()
     {
-        return $this->render('admin/users.html.twig', [
+        return $this->render('admin/users/index.html.twig', [
             'users' => $this->getDoctrine()->getRepository(User::class)->findAll(),
         ]);
     }
+
+	/**
+	 * @Route("/users/new", name="admin_users_new", methods={"GET", "POST"})
+	 * @IsGranted("ROLE_ADMIN")
+	 */
+    public function new(Request $request, FileUploader $fileUploader, ObjectManager $em): Response
+	{
+		$user = (new User())->setDisplayName('');
+
+		$form = $this->createForm(UserType::class, $user);
+		$form->handleRequest($request);
+
+		if ($form->isSubmitted() && $form->isValid()) {
+			if (($picture = $form['picture']->getData())) {
+				$user->setPicture($fileUploader->upload($picture, $this->getParameter('users_pictures_directory')));
+			}
+
+			$em->persist($user);
+			$em->flush();
+
+			$this->addFlash('success', 'users.success.create');
+
+			return $this->redirectToRoute('admin_users');
+		}
+
+		if ($form->isSubmitted() && !$form->isValid()) {
+			foreach ($form->getErrors() as $error) {
+				$this->addFlash('danger', $error->getMessage() . $error->getCause());
+			}
+		}
+
+		return $this->render('admin/users/new.html.twig', [
+			'user' => $user,
+			'form' => $form->createView(),
+		]);
+	}
 }

--- a/src/Controller/Admin/AdminController.php
+++ b/src/Controller/Admin/AdminController.php
@@ -108,6 +108,7 @@ class AdminController extends AbstractController
 
 	/**
 	 * @Route("/users/{uuid}/delete", name="admin_users_delete", methods={"POST"})
+	 * @IsGranted("ROLE_ADMIN")
 	 */
 	public function delete(User $user, Request $request, ObjectManager $em): Response
 	{

--- a/src/Controller/Admin/AdminController.php
+++ b/src/Controller/Admin/AdminController.php
@@ -29,7 +29,7 @@ class AdminController extends AbstractController
 
     /**
      * @Route("/users", name="admin_users")
-	 * @IsGranted("ROLE_ADMIN")
+     * @IsGranted("ROLE_ADMIN")
      */
     public function users()
     {
@@ -38,126 +38,126 @@ class AdminController extends AbstractController
         ]);
     }
 
-	/**
-	 * @Route("/users/new", name="admin_users_new", methods={"GET", "POST"})
-	 * @IsGranted("ROLE_ADMIN")
-	 */
+    /**
+     * @Route("/users/new", name="admin_users_new", methods={"GET", "POST"})
+     * @IsGranted("ROLE_ADMIN")
+     */
     public function new(Request $request, FileUploader $fileUploader, ObjectManager $em): Response
-	{
-		$user = (new User())->setDisplayName('');
+    {
+        $user = (new User())->setDisplayName('');
 
-		$form = $this->createForm(UserType::class, $user, [
-			'addRolesField' => true,
-			'choices'       => $this->getAvailableRoles(),
-		]);
-		$form->handleRequest($request);
+        $form = $this->createForm(UserType::class, $user, [
+            'addRolesField' => true,
+            'choices'       => $this->getAvailableRoles(),
+        ]);
+        $form->handleRequest($request);
 
-		if ($form->isSubmitted() && $form->isValid()) {
-			if (($picture = $form['picture']->getData())) {
-				$user->setPicture($fileUploader->upload($picture, $this->getParameter('users_pictures_directory')));
-			}
+        if ($form->isSubmitted() && $form->isValid()) {
+            if (($picture = $form['picture']->getData())) {
+                $user->setPicture($fileUploader->upload($picture, $this->getParameter('users_pictures_directory')));
+            }
 
-			$em->persist($user);
-			$em->flush();
+            $em->persist($user);
+            $em->flush();
 
-			$this->addFlash('success', 'users.success.create');
+            $this->addFlash('success', 'users.success.create');
 
-			return $this->redirectToRoute('admin_users');
-		}
+            return $this->redirectToRoute('admin_users');
+        }
 
-		if ($form->isSubmitted() && !$form->isValid()) {
-			foreach ($form->getErrors() as $error) {
-				$this->addFlash('danger', $error->getMessage() . $error->getCause());
-			}
-		}
+        if ($form->isSubmitted() && !$form->isValid()) {
+            foreach ($form->getErrors() as $error) {
+                $this->addFlash('danger', $error->getMessage() . $error->getCause());
+            }
+        }
 
-		return $this->render('admin/users/new.html.twig', [
-			'user' => $user,
-			'form' => $form->createView(),
-		]);
-	}
+        return $this->render('admin/users/new.html.twig', [
+            'user' => $user,
+            'form' => $form->createView(),
+        ]);
+    }
 
-	/**
-	 * @Route("/users/{uuid}/edit", name="admin_users_edit", methods={"GET", "POST"})
-	 * @IsGranted("ROLE_ADMIN")
-	 */
-	public function edit(User $user, Request $request, FileUploader $fileUploader, ObjectManager $em): Response
-	{
-		$addRolesField = $this->isEditRolesOrDeleteAllowed($user);
-		$form = $this->createForm(UserType::class, $user, [
-			'addRolesField' => $addRolesField,
-			'choices'       => $this->getAvailableRoles(),
-		]);
-		$form->handleRequest($request);
+    /**
+     * @Route("/users/{uuid}/edit", name="admin_users_edit", methods={"GET", "POST"})
+     * @IsGranted("ROLE_ADMIN")
+     */
+    public function edit(User $user, Request $request, FileUploader $fileUploader, ObjectManager $em): Response
+    {
+        $addRolesField = $this->isEditRolesOrDeleteAllowed($user);
+        $form = $this->createForm(UserType::class, $user, [
+            'addRolesField' => $addRolesField,
+            'choices'       => $this->getAvailableRoles(),
+        ]);
+        $form->handleRequest($request);
 
-		if ($form->isSubmitted() && $form->isValid()) {
-			if (($picture = $form['picture']->getData())) {
-				$user->setPicture($fileUploader->upload($picture, $this->getParameter('users_pictures_directory')));
-			}
+        if ($form->isSubmitted() && $form->isValid()) {
+            if (($picture = $form['picture']->getData())) {
+                $user->setPicture($fileUploader->upload($picture, $this->getParameter('users_pictures_directory')));
+            }
 
-			$em->flush();
+            $em->flush();
 
-			$this->addFlash('success', 'users.success.edit');
+            $this->addFlash('success', 'users.success.edit');
 
-			return $this->redirectToRoute('admin_users_edit', ['uuid' => $user->getUuidAsString()]);
-		}
+            return $this->redirectToRoute('admin_users_edit', ['uuid' => $user->getUuidAsString()]);
+        }
 
-		if ($form->isSubmitted() && !$form->isValid()) {
-			foreach ($form->getErrors() as $error) {
-				$this->addFlash('danger', $error->getMessage() . $error->getCause());
-			}
-		}
+        if ($form->isSubmitted() && !$form->isValid()) {
+            foreach ($form->getErrors() as $error) {
+                $this->addFlash('danger', $error->getMessage() . $error->getCause());
+            }
+        }
 
-		return $this->render('admin/users/edit.html.twig', [
-			'user'          => $user,
-			'form'          => $form->createView(),
-			'addRolesField' => $addRolesField,
-		]);
-	}
+        return $this->render('admin/users/edit.html.twig', [
+            'user'          => $user,
+            'form'          => $form->createView(),
+            'addRolesField' => $addRolesField,
+        ]);
+    }
 
-	private function getAvailableRoles(): array
-	{
-		return \array_filter(
-			User::getAvailableRoles(),
-			function (string $choice) {
-				return $this->isGranted($choice);
-			}
-		);
-	}
+    private function getAvailableRoles(): array
+    {
+        return \array_filter(
+            User::getAvailableRoles(),
+            function (string $choice) {
+                return $this->isGranted($choice);
+            }
+        );
+    }
 
-	/**
-	 * @Route("/users/{uuid}/delete", name="admin_users_delete", methods={"POST"})
-	 * @IsGranted("ROLE_ADMIN")
-	 */
-	public function delete(User $user, Request $request, Security $security, ObjectManager $em): Response
-	{
-		if (!$this->isEditRolesOrDeleteAllowed($user)) {
-			$this->addFlash('danger', 'users.fail.delete');
+    /**
+     * @Route("/users/{uuid}/delete", name="admin_users_delete", methods={"POST"})
+     * @IsGranted("ROLE_ADMIN")
+     */
+    public function delete(User $user, Request $request, Security $security, ObjectManager $em): Response
+    {
+        if (!$this->isEditRolesOrDeleteAllowed($user)) {
+            $this->addFlash('danger', 'users.fail.delete');
 
-			return $this->redirectToRoute('admin_users');
-		}
+            return $this->redirectToRoute('admin_users');
+        }
 
-		if ($user === $security->getUser()) {
-			$this->addFlash('danger', 'users.fail.delete');
+        if ($user === $security->getUser()) {
+            $this->addFlash('danger', 'users.fail.delete');
 
-			return $this->redirectToRoute('admin_users');
-		}
+            return $this->redirectToRoute('admin_users');
+        }
 
-		if (!$this->isCsrfTokenValid('delete', $request->get('token'))) {
-			return $this->redirectToRoute('admin_users');
-		}
+        if (!$this->isCsrfTokenValid('delete', $request->get('token'))) {
+            return $this->redirectToRoute('admin_users');
+        }
 
-		$em->remove($user);
-		$em->flush();
+        $em->remove($user);
+        $em->flush();
 
-		$this->addFlash('success', 'users.success.delete');
+        $this->addFlash('success', 'users.success.delete');
 
-		return $this->redirectToRoute('admin_users');
-	}
+        return $this->redirectToRoute('admin_users');
+    }
 
-	private function isEditRolesOrDeleteAllowed(User $user): bool
-	{
-		return $this->isGranted(User::ROLE_SUPER_ADMIN)
-			|| !($user->hasRole(User::ROLE_ADMIN) || $user->hasRole(User::ROLE_SUPER_ADMIN));
-	}
+    private function isEditRolesOrDeleteAllowed(User $user): bool
+    {
+        return $this->isGranted(User::ROLE_SUPER_ADMIN)
+            || !($user->hasRole(User::ROLE_ADMIN) || $user->hasRole(User::ROLE_SUPER_ADMIN));
+    }
 }

--- a/src/Entity/User/User.php
+++ b/src/Entity/User/User.php
@@ -209,9 +209,9 @@ class User implements UserInterface
     }
 
     public function hasRole(string $role): bool
-	{
-		return \in_array($role, $this->getRoles());
-	}
+    {
+        return \in_array($role, $this->getRoles());
+    }
 
     public function setRoles(array $roles): self
     {
@@ -221,14 +221,14 @@ class User implements UserInterface
     }
 
     public static function getAvailableRoles(): array
-	{
-		return [
-			self::ROLE_DEFAULT,
-			self::ROLE_REDACTEUR,
-			self::ROLE_ADMIN,
-			self::ROLE_SUPER_ADMIN,
-		];
-	}
+    {
+        return [
+            self::ROLE_DEFAULT,
+            self::ROLE_REDACTEUR,
+            self::ROLE_ADMIN,
+            self::ROLE_SUPER_ADMIN,
+        ];
+    }
 
     public function getPassword()
     {

--- a/src/Entity/User/User.php
+++ b/src/Entity/User/User.php
@@ -12,12 +12,14 @@ use Doctrine\ORM\Mapping as ORM;
 use Gedmo\Mapping\Annotation as Gedmo;
 use Ramsey\Uuid\Uuid;
 use Ramsey\Uuid\UuidInterface;
+use Symfony\Bridge\Doctrine\Validator\Constraints\UniqueEntity;
 use Symfony\Component\Security\Core\User\UserInterface;
 use Symfony\Component\Validator\Constraints as Assert;
 
 /**
  * @ORM\Entity(repositoryClass="App\Repository\User\UserRepository")
  * @Gedmo\SoftDeleteable(fieldName="deletedAt", timeAware=false)
+ * @UniqueEntity("email")
  */
 class User implements UserInterface
 {
@@ -205,6 +207,11 @@ class User implements UserInterface
 
         return array_unique($roles);
     }
+
+    public function hasRole(string $role): bool
+	{
+		return \in_array($role, $this->getRoles());
+	}
 
     public function setRoles(array $roles): self
     {

--- a/src/Entity/User/User.php
+++ b/src/Entity/User/User.php
@@ -213,6 +213,16 @@ class User implements UserInterface
         return $this;
     }
 
+    public static function getAvailableRoles(): array
+	{
+		return [
+			self::ROLE_DEFAULT,
+			self::ROLE_REDACTEUR,
+			self::ROLE_ADMIN,
+			self::ROLE_SUPER_ADMIN,
+		];
+	}
+
     public function getPassword()
     {
     }

--- a/src/Form/Admin/UserType.php
+++ b/src/Form/Admin/UserType.php
@@ -15,64 +15,74 @@ use Symfony\Contracts\Translation\TranslatorInterface;
 
 class UserType extends AbstractType
 {
-	/**
-	 * @var TranslatorInterface
-	 */
-	private $translator;
+    /**
+     * @var TranslatorInterface
+     */
+    private $translator;
 
-	public function __construct(TranslatorInterface $translator)
-	{
-		$this->translator = $translator;
-	}
+    public function __construct(TranslatorInterface $translator)
+    {
+        $this->translator = $translator;
+    }
 
-	public function configureOptions(OptionsResolver $resolver)
-	{
-		$resolver->setDefaults([
-			'addRolesField' => false,
-			'choices'       => [],
-		]);
-	}
+    public function configureOptions(OptionsResolver $resolver)
+    {
+        $resolver->setDefaults([
+            'addRolesField' => false,
+            'choices'       => [],
+        ]);
+    }
 
-	public function buildForm(FormBuilderInterface $builder, array $options)
-	{
-		$builder
-			->add('email', EmailType::class, ['required' => true])
-			->add('displayName', TextType::class, ['required' => true])
-			->add('firstname', TextType::class, ['required' => false])
-			->add('lastname', TextType::class, ['required' => false])
-			->add('picture', FileType::class, [
-				'mapped' => false,
-				'required' => false,
-				'constraints' => [
-					new Image(['maxSize' => '2048k']),
-				],
-				'attr' => [
-					'accept' => 'image/*',
-				],
-			])
-			->add('twitter', TextType::class, ['required' => false])
-			->add('facebook', TextType::class, ['required' => false])
-			->add('youtube', TextType::class, ['required' => false])
-			->add('twitch', TextType::class, ['required' => false])
-			->add('discord', TextType::class, ['required' => false])
-			->add('instagram', TextType::class, ['required' => false])
-			->add('save', SubmitType::class, [
-				'label' => $this->translator->trans('default.action.save', [], 'admin'),
-				'attr' => ['class' => 'btn right'],
-			]);
+    public function buildForm(FormBuilderInterface $builder, array $options)
+    {
+        $builder
+            ->add('email', EmailType::class, ['required' => true])
+            ->add('displayName', TextType::class, ['required' => true])
+            ->add('firstname', TextType::class, ['required' => false])
+            ->add('lastname', TextType::class, ['required' => false])
+            ->add(
+                'picture',
+                FileType::class,
+                [
+                    'mapped'      => false,
+                    'required'    => false,
+                    'constraints' => [
+                        new Image(['maxSize' => '2048k']),
+                    ],
+                    'attr'        => [
+                        'accept' => 'image/*',
+                    ],
+                ]
+            )
+            ->add('twitter', TextType::class, ['required' => false])
+            ->add('facebook', TextType::class, ['required' => false])
+            ->add('youtube', TextType::class, ['required' => false])
+            ->add('twitch', TextType::class, ['required' => false])
+            ->add('discord', TextType::class, ['required' => false])
+            ->add('instagram', TextType::class, ['required' => false])
+            ->add(
+                'save',
+                SubmitType::class,
+                [
+                    'label' => $this->translator->trans('default.action.save', [], 'admin'),
+                    'attr'  => ['class' => 'btn right'],
+                ]
+            );
 
-		if ($options['addRolesField']) {
-			$builder->add(
-				'roles', ChoiceType::class, [
-				'choices'      => $options['choices'],
-				'choice_label' => function ($choice, $key, $value) {
-					return $value;
-				},
-				'multiple'     => true,
-				'required'     => true,
-				'label_attr'   => ['class' => 'active'],
-			]
-			);
-		}
-	}
+        if ($options['addRolesField']) {
+            $builder->add(
+                'roles',
+                ChoiceType::class,
+                [
+                    'choices'      => $options['choices'],
+                    'choice_label' => function ($choice, $key, $value) {
+                        return $value;
+                    },
+                    'multiple'     => true,
+                    'required'     => true,
+                    'label_attr'   => ['class' => 'active'],
+                ]
+            );
+        }
+    }
 }

--- a/src/Form/Admin/UserType.php
+++ b/src/Form/Admin/UserType.php
@@ -2,8 +2,6 @@
 
 namespace App\Form\Admin;
 
-use App\Entity\Team\Role;
-use App\Entity\User\User;
 use Symfony\Component\Form\AbstractType;
 use Symfony\Component\Form\Extension\Core\Type\ChoiceType;
 use Symfony\Component\Form\Extension\Core\Type\EmailType;
@@ -11,6 +9,7 @@ use Symfony\Component\Form\Extension\Core\Type\FileType;
 use Symfony\Component\Form\Extension\Core\Type\SubmitType;
 use Symfony\Component\Form\Extension\Core\Type\TextType;
 use Symfony\Component\Form\FormBuilderInterface;
+use Symfony\Component\OptionsResolver\OptionsResolver;
 use Symfony\Component\Validator\Constraints\Image;
 use Symfony\Contracts\Translation\TranslatorInterface;
 
@@ -24,6 +23,14 @@ class UserType extends AbstractType
 	public function __construct(TranslatorInterface $translator)
 	{
 		$this->translator = $translator;
+	}
+
+	public function configureOptions(OptionsResolver $resolver)
+	{
+		$resolver->setDefaults([
+			'addRolesField' => false,
+			'choices'       => [],
+		]);
 	}
 
 	public function buildForm(FormBuilderInterface $builder, array $options)
@@ -43,15 +50,6 @@ class UserType extends AbstractType
 					'accept' => 'image/*',
 				],
 			])
-			->add('roles', ChoiceType::class, [
-				'choices' => User::getAvailableRoles(),
-				'choice_label' => function ($choice, $key, $value) {
-					return $value;
-				},
-				'multiple' => true,
-				'required' => true,
-                'label_attr' => ['class' => 'active'],
-			])
 			->add('twitter', TextType::class, ['required' => false])
 			->add('facebook', TextType::class, ['required' => false])
 			->add('youtube', TextType::class, ['required' => false])
@@ -62,5 +60,19 @@ class UserType extends AbstractType
 				'label' => $this->translator->trans('default.action.save', [], 'admin'),
 				'attr' => ['class' => 'btn right'],
 			]);
+
+		if ($options['addRolesField']) {
+			$builder->add(
+				'roles', ChoiceType::class, [
+				'choices'      => $options['choices'],
+				'choice_label' => function ($choice, $key, $value) {
+					return $value;
+				},
+				'multiple'     => true,
+				'required'     => true,
+				'label_attr'   => ['class' => 'active'],
+			]
+			);
+		}
 	}
 }

--- a/src/Form/Admin/UserType.php
+++ b/src/Form/Admin/UserType.php
@@ -1,0 +1,66 @@
+<?php
+
+namespace App\Form\Admin;
+
+use App\Entity\Team\Role;
+use App\Entity\User\User;
+use Symfony\Component\Form\AbstractType;
+use Symfony\Component\Form\Extension\Core\Type\ChoiceType;
+use Symfony\Component\Form\Extension\Core\Type\EmailType;
+use Symfony\Component\Form\Extension\Core\Type\FileType;
+use Symfony\Component\Form\Extension\Core\Type\SubmitType;
+use Symfony\Component\Form\Extension\Core\Type\TextType;
+use Symfony\Component\Form\FormBuilderInterface;
+use Symfony\Component\Validator\Constraints\Image;
+use Symfony\Contracts\Translation\TranslatorInterface;
+
+class UserType extends AbstractType
+{
+	/**
+	 * @var TranslatorInterface
+	 */
+	private $translator;
+
+	public function __construct(TranslatorInterface $translator)
+	{
+		$this->translator = $translator;
+	}
+
+	public function buildForm(FormBuilderInterface $builder, array $options)
+	{
+		$builder
+			->add('email', EmailType::class, ['required' => true])
+			->add('displayName', TextType::class, ['required' => true])
+			->add('firstname', TextType::class, ['required' => false])
+			->add('lastname', TextType::class, ['required' => false])
+			->add('picture', FileType::class, [
+				'mapped' => false,
+				'required' => false,
+				'constraints' => [
+					new Image(['maxSize' => '2048k']),
+				],
+				'attr' => [
+					'accept' => 'image/*',
+				],
+			])
+			->add('roles', ChoiceType::class, [
+				'choices' => User::getAvailableRoles(),
+				'choice_label' => function ($choice, $key, $value) {
+					return $value;
+				},
+				'multiple' => true,
+				'required' => true,
+                'label_attr' => ['class' => 'active'],
+			])
+			->add('twitter', TextType::class, ['required' => false])
+			->add('facebook', TextType::class, ['required' => false])
+			->add('youtube', TextType::class, ['required' => false])
+			->add('twitch', TextType::class, ['required' => false])
+			->add('discord', TextType::class, ['required' => false])
+			->add('instagram', TextType::class, ['required' => false])
+			->add('save', SubmitType::class, [
+				'label' => $this->translator->trans('default.action.save', [], 'admin'),
+				'attr' => ['class' => 'btn right'],
+			]);
+	}
+}

--- a/src/Security/DiscordAuthenticator.php
+++ b/src/Security/DiscordAuthenticator.php
@@ -76,16 +76,7 @@ class DiscordAuthenticator extends SocialAuthenticator
             return $user;
         }
 
-        $user = new User();
-        $user->setEmail($discordUser->getEmail());
-        $user->setDisplayName($discordUser->getUsername());
-        $user->setDiscordId($discordUser->getId());
-        $user->setDiscord($discordUser->getUsername().'#'.$discordUser->getDiscriminator());
-        $user->setRoles([User::ROLE_DEFAULT]);
-        $this->entityManager->persist($user);
-        $this->entityManager->flush();
-
-        return $user;
+        return null;
     }
 
     public function onAuthenticationFailure(Request $request, AuthenticationException $exception)

--- a/templates/admin/_sidenav.html.twig
+++ b/templates/admin/_sidenav.html.twig
@@ -30,8 +30,6 @@
 		<li>
 			<a class="nav-link {{ _self.activeLink('admin_streamers') }}" href="{{ path('admin_streamers_index') }}"><i class="fab fa-fw fa-twitch mr-2 fa-2x"></i> Streamers</a>
 		</li>
-	{% endif %}
-	{% if is_granted('ROLE_SUPER_ADMIN') %}
 		<li>
 			<a class="nav-link {{ _self.activeLink('admin_users') }}" href="{{ path('admin_users') }}"><i class="fa fa-fw fa-handshake mr-2 fa-2x"></i> Utilisateurs</a>
 		</li>

--- a/templates/admin/users/edit.html.twig
+++ b/templates/admin/users/edit.html.twig
@@ -41,8 +41,12 @@
 			<div class="file-path-wrapper"><input class="file-path" type="text" id="file-placeholder"></div>
 		</div>
 		<div class="input-field col s6">
-			{{ form_label(form.roles) }}
-			{{ form_widget(form.roles) }}
+			{% if addRolesField %}
+				{{ form_label(form.roles) }}
+				{{ form_widget(form.roles) }}
+			{% else %}
+				{{ user.roles|join(', ') }}
+			{% endif %}
 		</div>
 	</div>
 	<div class="row">

--- a/templates/admin/users/edit.html.twig
+++ b/templates/admin/users/edit.html.twig
@@ -1,0 +1,88 @@
+{% extends 'admin/admin.html.twig' %}
+
+{% block content %}
+
+	<div class="row">
+		<div class="col s12">
+			<h2>{{ user.displayName }}
+
+				{% if user.picture is not null %}
+					<img src="{{ asset('uploads/users/' ~ user.picture) }}" alt="{{ user.displayName }}" class="right">
+				{% endif %}
+			</h2>
+		</div>
+	</div>
+
+	{{ form_start(form) }}
+	<div class="row">
+		<div class="input-field col s6">
+			{{ form_label(form.email) }}
+			{{ form_widget(form.email) }}
+		</div>
+		<div class="input-field col s6">
+			{{ form_label(form.displayName) }}
+			{{ form_widget(form.displayName) }}
+		</div>
+	</div>
+	<div class="row">
+		<div class="input-field col s6">
+			{{ form_label(form.firstname) }}
+			{{ form_widget(form.firstname) }}
+		</div>
+		<div class="input-field col s6">
+			{{ form_label(form.lastname) }}
+			{{ form_widget(form.lastname) }}
+		</div>
+	</div>
+	<div class="row">
+		<div class="file-field input-field col s6">
+			<label for="file-placeholder" class="active">Picture</label>
+			<div class="btn"><span>File</span> {{ form_widget(form.picture) }}</div>
+			<div class="file-path-wrapper"><input class="file-path" type="text" id="file-placeholder"></div>
+		</div>
+		<div class="input-field col s6">
+			{{ form_label(form.roles) }}
+			{{ form_widget(form.roles) }}
+		</div>
+	</div>
+	<div class="row">
+		<div class="input-field col s4">
+			<i class="fab fa-twitter prefix"></i>
+			{{ form_label(form.twitter) }}
+			{{ form_widget(form.twitter) }}
+		</div>
+		<div class="input-field col s4">
+			<i class="fab fa-facebook prefix"></i>
+			{{ form_label(form.facebook) }}
+			{{ form_widget(form.facebook) }}
+		</div>
+		<div class="input-field col s4">
+			<i class="fab fa-youtube prefix"></i>
+			{{ form_label(form.youtube) }}
+			{{ form_widget(form.youtube) }}
+		</div>
+	</div>
+	<div class="row">
+		<div class="input-field col s4">
+			<i class="fab fa-twitch prefix"></i>
+			{{ form_label(form.twitch) }}
+			{{ form_widget(form.twitch) }}
+		</div>
+		<div class="input-field col s4">
+			<i class="fab fa-discord prefix"></i>
+			{{ form_label(form.discord) }}
+			{{ form_widget(form.discord) }}
+		</div>
+		<div class="input-field col s4">
+			<i class="fab fa-instagram prefix"></i>
+			{{ form_label(form.instagram) }}
+			{{ form_widget(form.instagram) }}
+		</div>
+	</div>
+	<div class="row">
+		<div class="input-field">
+			{{ form_row(form.save) }}
+		</div>
+	</div>
+	{{ form_end(form) }}
+{% endblock %}

--- a/templates/admin/users/edit.html.twig
+++ b/templates/admin/users/edit.html.twig
@@ -2,91 +2,91 @@
 
 {% block content %}
 
-	<div class="row">
-		<div class="col s12">
-			<h2>{{ user.displayName }}
+    <div class="row">
+        <div class="col s12">
+            <h2>{{ user.displayName }}
 
-				{% if user.picture is not null %}
-					<img src="{{ asset('uploads/users/' ~ user.picture) }}" alt="{{ user.displayName }}" class="right">
-				{% endif %}
-			</h2>
-		</div>
-	</div>
+                {% if user.picture is not null %}
+                    <img src="{{ asset('uploads/users/' ~ user.picture) }}" alt="{{ user.displayName }}" class="right">
+                {% endif %}
+            </h2>
+        </div>
+    </div>
 
-	{{ form_start(form) }}
-	<div class="row">
-		<div class="input-field col s6">
-			{{ form_label(form.email) }}
-			{{ form_widget(form.email) }}
-		</div>
-		<div class="input-field col s6">
-			{{ form_label(form.displayName) }}
-			{{ form_widget(form.displayName) }}
-		</div>
-	</div>
-	<div class="row">
-		<div class="input-field col s6">
-			{{ form_label(form.firstname) }}
-			{{ form_widget(form.firstname) }}
-		</div>
-		<div class="input-field col s6">
-			{{ form_label(form.lastname) }}
-			{{ form_widget(form.lastname) }}
-		</div>
-	</div>
-	<div class="row">
-		<div class="file-field input-field col s6">
-			<label for="file-placeholder" class="active">Picture</label>
-			<div class="btn"><span>File</span> {{ form_widget(form.picture) }}</div>
-			<div class="file-path-wrapper"><input class="file-path" type="text" id="file-placeholder"></div>
-		</div>
-		<div class="input-field col s6">
-			{% if addRolesField %}
-				{{ form_label(form.roles) }}
-				{{ form_widget(form.roles) }}
-			{% else %}
-				{{ user.roles|join(', ') }}
-			{% endif %}
-		</div>
-	</div>
-	<div class="row">
-		<div class="input-field col s4">
-			<i class="fab fa-twitter prefix"></i>
-			{{ form_label(form.twitter) }}
-			{{ form_widget(form.twitter) }}
-		</div>
-		<div class="input-field col s4">
-			<i class="fab fa-facebook prefix"></i>
-			{{ form_label(form.facebook) }}
-			{{ form_widget(form.facebook) }}
-		</div>
-		<div class="input-field col s4">
-			<i class="fab fa-youtube prefix"></i>
-			{{ form_label(form.youtube) }}
-			{{ form_widget(form.youtube) }}
-		</div>
-	</div>
-	<div class="row">
-		<div class="input-field col s4">
-			<i class="fab fa-twitch prefix"></i>
-			{{ form_label(form.twitch) }}
-			{{ form_widget(form.twitch) }}
-		</div>
-		<div class="input-field col s4">
-			<i class="fab fa-discord prefix"></i>
-			{{ form_label(form.discord) }}
-			{{ form_widget(form.discord) }}
-		</div>
-		<div class="input-field col s4">
-			<i class="fab fa-instagram prefix"></i>
-			{{ form_label(form.instagram) }}
-			{{ form_widget(form.instagram) }}
-		</div>
-	</div>
-	<div class="row">
-		<div class="input-field">
-			{{ form_row(form.save) }}
-		</div>
-	</div>
-	{{ form_end(form) }}
+    {{ form_start(form) }}
+    <div class="row">
+        <div class="input-field col s6">
+            {{ form_label(form.email) }}
+            {{ form_widget(form.email) }}
+        </div>
+        <div class="input-field col s6">
+            {{ form_label(form.displayName) }}
+            {{ form_widget(form.displayName) }}
+        </div>
+    </div>
+    <div class="row">
+        <div class="input-field col s6">
+            {{ form_label(form.firstname) }}
+            {{ form_widget(form.firstname) }}
+        </div>
+        <div class="input-field col s6">
+            {{ form_label(form.lastname) }}
+            {{ form_widget(form.lastname) }}
+        </div>
+    </div>
+    <div class="row">
+        <div class="file-field input-field col s6">
+            <label for="file-placeholder" class="active">Picture</label>
+            <div class="btn"><span>File</span> {{ form_widget(form.picture) }}</div>
+            <div class="file-path-wrapper"><input class="file-path" type="text" id="file-placeholder"></div>
+        </div>
+        <div class="input-field col s6">
+            {% if addRolesField %}
+                {{ form_label(form.roles) }}
+                {{ form_widget(form.roles) }}
+            {% else %}
+                {{ user.roles|join(', ') }}
+            {% endif %}
+        </div>
+    </div>
+    <div class="row">
+        <div class="input-field col s4">
+            <i class="fab fa-twitter prefix"></i>
+            {{ form_label(form.twitter) }}
+            {{ form_widget(form.twitter) }}
+        </div>
+        <div class="input-field col s4">
+            <i class="fab fa-facebook prefix"></i>
+            {{ form_label(form.facebook) }}
+            {{ form_widget(form.facebook) }}
+        </div>
+        <div class="input-field col s4">
+            <i class="fab fa-youtube prefix"></i>
+            {{ form_label(form.youtube) }}
+            {{ form_widget(form.youtube) }}
+        </div>
+    </div>
+    <div class="row">
+        <div class="input-field col s4">
+            <i class="fab fa-twitch prefix"></i>
+            {{ form_label(form.twitch) }}
+            {{ form_widget(form.twitch) }}
+        </div>
+        <div class="input-field col s4">
+            <i class="fab fa-discord prefix"></i>
+            {{ form_label(form.discord) }}
+            {{ form_widget(form.discord) }}
+        </div>
+        <div class="input-field col s4">
+            <i class="fab fa-instagram prefix"></i>
+            {{ form_label(form.instagram) }}
+            {{ form_widget(form.instagram) }}
+        </div>
+    </div>
+    <div class="row">
+        <div class="input-field">
+            {{ form_row(form.save) }}
+        </div>
+    </div>
+    {{ form_end(form) }}
 {% endblock %}

--- a/templates/admin/users/index.html.twig
+++ b/templates/admin/users/index.html.twig
@@ -5,7 +5,7 @@
 
 {% block content %}
 	<h2>{{ 'users.index.title'|trans }}
-		<a href="{{ path('admin') }}" class="btn green right">
+		<a href="{{ path('admin_users_new') }}" class="btn green right">
 			{{ 'default.action.add'|trans }}
 			<i class="fa fa-plus" aria-hidden="true"></i>
 		</a>

--- a/templates/admin/users/index.html.twig
+++ b/templates/admin/users/index.html.twig
@@ -24,7 +24,7 @@
 		{% for user in users %}
 			<tr>
 				<td>{{ user.displayName }}</td>
-				<td>{% for role in user.roles %}{{ role }}{% endfor %}</td>
+				<td>{{ user.roles|join(', ') }}</td>
 				<td>{{ user.createdAt| date('d/m/y H:i') }}</td>
 				<td class="right-align">
 					<div class="item-actions">

--- a/templates/admin/users/index.html.twig
+++ b/templates/admin/users/index.html.twig
@@ -4,51 +4,52 @@
 {% block body_id 'users' %}
 
 {% block content %}
-	<h2>{{ 'users.index.title'|trans }}
-		<a href="{{ path('admin_users_new') }}" class="btn green right">
-			{{ 'default.action.add'|trans }}
-			<i class="fa fa-plus" aria-hidden="true"></i>
-		</a>
-	</h2>
+    <h2>{{ 'users.index.title'|trans }}
+        <a href="{{ path('admin_users_new') }}" class="btn green right">
+            {{ 'default.action.add'|trans }}
+            <i class="fa fa-plus" aria-hidden="true"></i>
+        </a>
+    </h2>
 
-	<table class="table table-striped table-middle-aligned">
-		<thead>
-		<tr>
-			<th scope="col">{{ 'users.index.label.name'|trans }}</th>
-			<th scope="col">{{ 'users.index.label.role'|trans }}</th>
-			<th scope="col"><i class="fa fa-pencil-alt" aria-hidden="true"></i> {{ 'users.index.label.joined'|trans }}</th>
-			<th scope="col" class="center-align"><i class="fa fa-cogs" aria-hidden="true"></i> {{ 'users.index.label.actions'|trans }}</th>
-		</tr>
-		</thead>
-		<tbody>
-		{% for user in users %}
-			<tr>
-				<td>{{ user.displayName }}</td>
-				<td>{{ user.roles|join(', ') }}</td>
-				<td>{{ user.createdAt| date('d/m/y H:i') }}</td>
-				<td class="right-align">
-					<div class="item-actions">
-						<a href="{{ path('admin_users_edit', {uuid: user.uuidAsString}) }}" class="btn teal">
-							{{ 'default.action.edit'|trans }}
-							<i class="fa fa-edit" aria-hidden="true"></i>
-						</a>
-						<form action="{{ url('admin_users_delete', {uuid: user.uuidAsString}) }}" method="post" data-confirmation="true" id="delete-form" style="display:inline-block">
-							<input type="hidden" name="token" value="{{ csrf_token('delete') }}" />
-							<button type="submit" class="btn red">
-								{{ 'default.action.delete'|trans }}
-								<i class="fa fa-trash" aria-hidden="true"></i>
-							</button>
-						</form>
-					</div>
-				</td>
-			</tr>
-		{% else %}
-			<tr>
-				<td colspan="4" align="center">{{ 'users.index.no_results'|trans }}</td>
-			</tr>
-		{% endfor %}
-		</tbody>
-	</table>
+    <table class="table table-striped table-middle-aligned">
+        <thead>
+        <tr>
+            <th scope="col">{{ 'users.index.label.name'|trans }}</th>
+            <th scope="col">{{ 'users.index.label.role'|trans }}</th>
+            <th scope="col"><i class="fa fa-pencil-alt" aria-hidden="true"></i> {{ 'users.index.label.joined'|trans }}
+            </th>
+            <th scope="col" class="center-align"><i class="fa fa-cogs" aria-hidden="true"></i> {{ 'users.index.label.actions'|trans }}</th>
+        </tr>
+        </thead>
+        <tbody>
+        {% for user in users %}
+            <tr>
+                <td>{{ user.displayName }}</td>
+                <td>{{ user.roles|join(', ') }}</td>
+                <td>{{ user.createdAt| date('d/m/y H:i') }}</td>
+                <td class="right-align">
+                    <div class="item-actions">
+                        <a href="{{ path('admin_users_edit', {uuid: user.uuidAsString}) }}" class="btn teal">
+                            {{ 'default.action.edit'|trans }}
+                            <i class="fa fa-edit" aria-hidden="true"></i>
+                        </a>
+                        <form action="{{ url('admin_users_delete', {uuid: user.uuidAsString}) }}" method="post" data-confirmation="true" id="delete-form" style="display:inline-block">
+                            <input type="hidden" name="token" value="{{ csrf_token('delete') }}"/>
+                            <button type="submit" class="btn red">
+                                {{ 'default.action.delete'|trans }}
+                                <i class="fa fa-trash" aria-hidden="true"></i>
+                            </button>
+                        </form>
+                    </div>
+                </td>
+            </tr>
+        {% else %}
+            <tr>
+                <td colspan="4" align="center">{{ 'users.index.no_results'|trans }}</td>
+            </tr>
+        {% endfor %}
+        </tbody>
+    </table>
 {% endblock %}
 
 

--- a/templates/admin/users/index.html.twig
+++ b/templates/admin/users/index.html.twig
@@ -28,11 +28,11 @@
 				<td>{{ user.createdAt| date('d/m/y H:i') }}</td>
 				<td class="right-align">
 					<div class="item-actions">
-						<a href="{{ path('admin', {uuid: user.uuidAsString}) }}" class="btn teal">
+						<a href="{{ path('admin_users_edit', {uuid: user.uuidAsString}) }}" class="btn teal">
 							{{ 'default.action.edit'|trans }}
 							<i class="fa fa-edit" aria-hidden="true"></i>
 						</a>
-						<form action="{{ url('admin', {uuid: user.uuidAsString}) }}" method="post" data-confirmation="true" id="delete-form" style="display:inline-block">
+						<form action="{{ url('admin_users_delete', {uuid: user.uuidAsString}) }}" method="post" data-confirmation="true" id="delete-form" style="display:inline-block">
 							<input type="hidden" name="token" value="{{ csrf_token('delete') }}" />
 							<button type="submit" class="btn red">
 								{{ 'default.action.delete'|trans }}

--- a/templates/admin/users/new.html.twig
+++ b/templates/admin/users/new.html.twig
@@ -1,78 +1,78 @@
 {% extends 'admin/admin.html.twig' %}
 
 {% block content %}
-	<h2>Ajouter un Utilisateur</h2>
+    <h2>Ajouter un Utilisateur</h2>
 
-	{{ form_start(form) }}
-	<div class="row">
-		<div class="input-field col s6">
-			{{ form_label(form.email) }}
-			{{ form_widget(form.email) }}
-		</div>
-		<div class="input-field col s6">
-			{{ form_label(form.displayName) }}
-			{{ form_widget(form.displayName) }}
-		</div>
-	</div>
-	<div class="row">
-		<div class="input-field col s6">
-			{{ form_label(form.firstname) }}
-			{{ form_widget(form.firstname) }}
-		</div>
-		<div class="input-field col s6">
-			{{ form_label(form.lastname) }}
-			{{ form_widget(form.lastname) }}
-		</div>
-	</div>
-	<div class="row">
-		<div class="file-field input-field col s6">
-			<label for="file-placeholder" class="active">Picture</label>
-			<div class="btn"><span>File</span> {{ form_widget(form.picture) }}</div>
-			<div class="file-path-wrapper"><input class="file-path" type="text" id="file-placeholder"></div>
-		</div>
-		<div class="input-field col s6">
-			{{ form_label(form.roles) }}
-			{{ form_widget(form.roles) }}
-		</div>
-	</div>
-	<div class="row">
-		<div class="input-field col s4">
-			<i class="fab fa-twitter prefix"></i>
-			{{ form_label(form.twitter) }}
-			{{ form_widget(form.twitter) }}
-		</div>
-		<div class="input-field col s4">
-			<i class="fab fa-facebook prefix"></i>
-			{{ form_label(form.facebook) }}
-			{{ form_widget(form.facebook) }}
-		</div>
-		<div class="input-field col s4">
-			<i class="fab fa-youtube prefix"></i>
-			{{ form_label(form.youtube) }}
-			{{ form_widget(form.youtube) }}
-		</div>
-	</div>
-	<div class="row">
-		<div class="input-field col s4">
-			<i class="fab fa-twitch prefix"></i>
-			{{ form_label(form.twitch) }}
-			{{ form_widget(form.twitch) }}
-		</div>
-		<div class="input-field col s4">
-			<i class="fab fa-discord prefix"></i>
-			{{ form_label(form.discord) }}
-			{{ form_widget(form.discord) }}
-		</div>
-		<div class="input-field col s4">
-			<i class="fab fa-instagram prefix"></i>
-			{{ form_label(form.instagram) }}
-			{{ form_widget(form.instagram) }}
-		</div>
-	</div>
-	<div class="row">
-		<div class="input-field">
-			{{ form_row(form.save) }}
-		</div>
-	</div>
-	{{ form_end(form) }}
+    {{ form_start(form) }}
+    <div class="row">
+        <div class="input-field col s6">
+            {{ form_label(form.email) }}
+            {{ form_widget(form.email) }}
+        </div>
+        <div class="input-field col s6">
+            {{ form_label(form.displayName) }}
+            {{ form_widget(form.displayName) }}
+        </div>
+    </div>
+    <div class="row">
+        <div class="input-field col s6">
+            {{ form_label(form.firstname) }}
+            {{ form_widget(form.firstname) }}
+        </div>
+        <div class="input-field col s6">
+            {{ form_label(form.lastname) }}
+            {{ form_widget(form.lastname) }}
+        </div>
+    </div>
+    <div class="row">
+        <div class="file-field input-field col s6">
+            <label for="file-placeholder" class="active">Picture</label>
+            <div class="btn"><span>File</span> {{ form_widget(form.picture) }}</div>
+            <div class="file-path-wrapper"><input class="file-path" type="text" id="file-placeholder"></div>
+        </div>
+        <div class="input-field col s6">
+            {{ form_label(form.roles) }}
+            {{ form_widget(form.roles) }}
+        </div>
+    </div>
+    <div class="row">
+        <div class="input-field col s4">
+            <i class="fab fa-twitter prefix"></i>
+            {{ form_label(form.twitter) }}
+            {{ form_widget(form.twitter) }}
+        </div>
+        <div class="input-field col s4">
+            <i class="fab fa-facebook prefix"></i>
+            {{ form_label(form.facebook) }}
+            {{ form_widget(form.facebook) }}
+        </div>
+        <div class="input-field col s4">
+            <i class="fab fa-youtube prefix"></i>
+            {{ form_label(form.youtube) }}
+            {{ form_widget(form.youtube) }}
+        </div>
+    </div>
+    <div class="row">
+        <div class="input-field col s4">
+            <i class="fab fa-twitch prefix"></i>
+            {{ form_label(form.twitch) }}
+            {{ form_widget(form.twitch) }}
+        </div>
+        <div class="input-field col s4">
+            <i class="fab fa-discord prefix"></i>
+            {{ form_label(form.discord) }}
+            {{ form_widget(form.discord) }}
+        </div>
+        <div class="input-field col s4">
+            <i class="fab fa-instagram prefix"></i>
+            {{ form_label(form.instagram) }}
+            {{ form_widget(form.instagram) }}
+        </div>
+    </div>
+    <div class="row">
+        <div class="input-field">
+            {{ form_row(form.save) }}
+        </div>
+    </div>
+    {{ form_end(form) }}
 {% endblock %}

--- a/templates/admin/users/new.html.twig
+++ b/templates/admin/users/new.html.twig
@@ -1,0 +1,78 @@
+{% extends 'admin/admin.html.twig' %}
+
+{% block content %}
+	<h2>Ajouter un Utilisateur</h2>
+
+	{{ form_start(form) }}
+	<div class="row">
+		<div class="input-field col s6">
+			{{ form_label(form.email) }}
+			{{ form_widget(form.email) }}
+		</div>
+		<div class="input-field col s6">
+			{{ form_label(form.displayName) }}
+			{{ form_widget(form.displayName) }}
+		</div>
+	</div>
+	<div class="row">
+		<div class="input-field col s6">
+			{{ form_label(form.firstname) }}
+			{{ form_widget(form.firstname) }}
+		</div>
+		<div class="input-field col s6">
+			{{ form_label(form.lastname) }}
+			{{ form_widget(form.lastname) }}
+		</div>
+	</div>
+	<div class="row">
+		<div class="file-field input-field col s6">
+			<label for="file-placeholder" class="active">Picture</label>
+			<div class="btn"><span>File</span> {{ form_widget(form.picture) }}</div>
+			<div class="file-path-wrapper"><input class="file-path" type="text" id="file-placeholder"></div>
+		</div>
+		<div class="input-field col s6">
+			{{ form_label(form.roles) }}
+			{{ form_widget(form.roles) }}
+		</div>
+	</div>
+	<div class="row">
+		<div class="input-field col s4">
+			<i class="fab fa-twitter prefix"></i>
+			{{ form_label(form.twitter) }}
+			{{ form_widget(form.twitter) }}
+		</div>
+		<div class="input-field col s4">
+			<i class="fab fa-facebook prefix"></i>
+			{{ form_label(form.facebook) }}
+			{{ form_widget(form.facebook) }}
+		</div>
+		<div class="input-field col s4">
+			<i class="fab fa-youtube prefix"></i>
+			{{ form_label(form.youtube) }}
+			{{ form_widget(form.youtube) }}
+		</div>
+	</div>
+	<div class="row">
+		<div class="input-field col s4">
+			<i class="fab fa-twitch prefix"></i>
+			{{ form_label(form.twitch) }}
+			{{ form_widget(form.twitch) }}
+		</div>
+		<div class="input-field col s4">
+			<i class="fab fa-discord prefix"></i>
+			{{ form_label(form.discord) }}
+			{{ form_widget(form.discord) }}
+		</div>
+		<div class="input-field col s4">
+			<i class="fab fa-instagram prefix"></i>
+			{{ form_label(form.instagram) }}
+			{{ form_widget(form.instagram) }}
+		</div>
+	</div>
+	<div class="row">
+		<div class="input-field">
+			{{ form_row(form.save) }}
+		</div>
+	</div>
+	{{ form_end(form) }}
+{% endblock %}

--- a/translations/flash_messages.fr.yaml
+++ b/translations/flash_messages.fr.yaml
@@ -34,3 +34,8 @@ streamers.fail.edit: Une erreur s'est produite
 streamers.fail.delete: Une erreur s'est produite
 
 users.success.create: Utilisateur créé !
+users.success.edit: Succès !
+users.success.delete: Succès !
+users.fail.create: Une erreur s'est produite
+users.fail.edit: Une erreur s'est produite
+users.fail.delete: Une erreur s'est produite

--- a/translations/flash_messages.fr.yaml
+++ b/translations/flash_messages.fr.yaml
@@ -32,3 +32,5 @@ streamers.success.delete: Succès !
 streamers.fail.create: Une erreur s'est produite
 streamers.fail.edit: Une erreur s'est produite
 streamers.fail.delete: Une erreur s'est produite
+
+users.success.create: Utilisateur créé !


### PR DESCRIPTION
This PR handles Issue #86 .
I added views, forms and controller actions to add, edit and delete users.
On create users, the available roles depend on the logged-in user's role, so a user with role `ROLE_ADMIN` can't create a user with role `ROLE_SUPER_ADMIN`. Additionally, I added a constraint for unique email addresses on users.
Like you described in the issue, the user is not allowed to edit the user's role the user is admin or super admin and the logged-in user is not super admin.
On deleting users I added checks to prevent deleting admin or super admins if the logged-in user is no super admin and also deleting the logged-in user.